### PR TITLE
prevent animation if angle not changed

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -106,7 +106,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -141,7 +141,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   typed_data:
     dependency: transitive
     description:

--- a/lib/src/circular_slider.dart
+++ b/lib/src/circular_slider.dart
@@ -80,7 +80,8 @@ class _SleekCircularSliderState extends State<SleekCircularSlider>
 
   @override
   void didUpdateWidget(SleekCircularSlider oldWidget) {
-    if (oldWidget.angle != widget.angle) {
+    if (oldWidget.angle != widget.angle &&
+        _currentAngle?.toStringAsFixed(4) != widget.angle.toStringAsFixed(4)) {
       _animate();
     }
     super.didUpdateWidget(oldWidget);
@@ -93,12 +94,12 @@ class _SleekCircularSliderState extends State<SleekCircularSlider>
       return;
     }
     if (_animationManager == null) {
-	    _animationManager = ValueChangedAnimationManager(
-		    tickerProvider: this,
-		    minValue: widget.min,
-		    maxValue: widget.max,
-		    durationMultiplier: widget.appearance.animDurationMultiplier,
-	    );
+      _animationManager = ValueChangedAnimationManager(
+        tickerProvider: this,
+        minValue: widget.min,
+        maxValue: widget.max,
+        durationMultiplier: widget.appearance.animDurationMultiplier,
+      );
     }
 
     _animationManager!.animate(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -92,7 +92,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -127,7 +127,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
Hi @matthewfx 
Thanks for package.

I'm writing a wrapper `reactive_sleek_circular_slider` for `reactive_forms` package.
Basically I'm supporting this form engine by writing as much prebuilt wrappers as possible.

Currently I have an issue when using it with forms.

I swipe to change then I update `initialValue` to be in sync with form and to allow to change values programmaticaly.
In this case slider animates despite current and upcoming angles are the same.